### PR TITLE
BUILD: Add bandit and upgrade flake8-quotes

### DIFF
--- a/backend/requirements.dev.txt
+++ b/backend/requirements.dev.txt
@@ -6,8 +6,9 @@ flake8-black==0.1.1
 flake8==3.7.9
 flake8-mock==0.3
 flake8-commas==2.0.0
-flake8-quotes==2.1.1
+flake8-quotes==3.0.0
 flake8-debugger==3.2.1
 flake8-builtins==1.5.2
 flake8-deprecated==1.3
 flake8-comprehensions==3.2.2
+bandit==1.6.2


### PR DESCRIPTION
CI in codebuild was failing due to missing bandit. Turns out this https://github.com/bequest/zygoat/pull/47 change from zygoat was needed.
The `flake8-quotes` got upgraded when I ran zygoat.