### PR TITLE
Set CSRF cookie on page load

### DIFF
--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -1,6 +1,6 @@
 from django.http import HttpResponse
 from django.views.decorators.http import require_http_methods
-from django.views.decorators.csrf import ensure_csrf_cookie
+from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -14,6 +14,7 @@ def is_authenticated(request):
     return Response(content)
 
 
+@csrf_exempt
 @ensure_csrf_cookie
 @require_http_methods(["GET", "POST"])
 def set_csrf(request):

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -1,6 +1,6 @@
 from django.http import HttpResponse
-from django.views.decorators.http import require_http_methods
-from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt
+from django.views.decorators.http import require_GET
+from django.views.decorators.csrf import ensure_csrf_cookie
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -14,8 +14,7 @@ def is_authenticated(request):
     return Response(content)
 
 
-@csrf_exempt
 @ensure_csrf_cookie
-@require_http_methods(["GET", "POST"])
+@require_GET
 def set_csrf(request):
     return HttpResponse("success", status=HTTP_200_OK)

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -17,7 +17,7 @@ const App = ({ Component, pageProps }) => {
 
   useEffect(() => {
     // Ensure the CSRF cookie is set.
-    setupCsrf()
+    setupCsrf();
   }, []);
 
   return (

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { ThemeProvider } from '@material-ui/core/styles';
 import theme from '@wui/theme';
+import { setupCsrf } from '../utils/API';
 
 const App = ({ Component, pageProps }) => {
   useEffect(() => {
@@ -13,6 +14,11 @@ const App = ({ Component, pageProps }) => {
       jssStyles.parentElement.removeChild(jssStyles);
     }
   });
+
+  useEffect(() => {
+    // Ensure the CSRF cookie is set.
+    setupCsrf()
+  }, []);
 
   return (
     <ThemeProvider theme={theme}>

--- a/frontend/utils/API.js
+++ b/frontend/utils/API.js
@@ -11,7 +11,7 @@ const API = axios.create({
   },
 });
 
-const setupCsrf = () => API.post('set_csrf');
+const setupCsrf = () => API.get('set_csrf');
 
 const register = payload => API.post('auth/register', payload);
 

--- a/frontend/utils/API.js
+++ b/frontend/utils/API.js
@@ -8,8 +8,8 @@ const API = axios.create({
     'X-REQUESTED-WITH': 'XMLHttpRequest',
     'Content-Type': 'application/json',
     'X-CSRFToken': Cookies.get('csrftoken'),
- },
-})
+  },
+});
 
 const setupCsrf = () => API.post('set_csrf');
 
@@ -21,10 +21,4 @@ const logout = () => API.post('auth/logout');
 
 const refresh = () => API.post('auth/token/refresh');
 
-export {
-  setupCsrf,
-  register,
-  login,
-  logout,
-  refresh,
-}
+export { setupCsrf, register, login, logout, refresh };

--- a/frontend/utils/API.js
+++ b/frontend/utils/API.js
@@ -11,6 +11,8 @@ const API = axios.create({
  },
 })
 
+const setupCsrf = () => API.post('set_csrf');
+
 const register = payload => API.post('auth/register', payload);
 
 const login = payload => API.post('auth/login', payload);
@@ -20,6 +22,7 @@ const logout = () => API.post('auth/logout');
 const refresh = () => API.post('auth/token/refresh');
 
 export {
+  setupCsrf,
   register,
   login,
   logout,


### PR DESCRIPTION
#21 got messed up because I pushed during the outage and it never updated with the commits I added to my remote branch after that. So this is that PR, with the suggested feedback changes of only allowing `GET` requests.

Tested with all changes, works.