### PR TITLE
Ignore backend settings file when run from 'backend' dir with Flake8

### DIFF
--- a/backend/.flake8
+++ b/backend/.flake8
@@ -1,6 +1,8 @@
 [flake8]
 max-line-length = 95
 exclude = .git, __pycache, .pycharm_helpers, */migrations/*, node_modules, bower_components, venv
-per-file-ignores = backend/backend/settings/__init__.py:F405
+per-file-ignores =
+    backend/backend/settings/__init__.py:F405
+    backend/settings/__init__.py:F405
 extend-ignore = E126,B003,Q001,A003,E203,E501,Q000,C812,E231,C819
 # See https://github.com/PyCQA/pycodestyle/issues/373


### PR DESCRIPTION
This is pretty hacky, but it'll get linting to run and pass correctly on the CI build. If this is an ok solution, I'll add it to the zygoat repo file. Right now, linting is failing on all the new PRs. I'd swear it didn't on the original PR adding in codebuild stuff.... ?? But now that commit is marked as failed as well.

The problem is that the path to the backend file is specified from the root dir, but the flake8 CI command is run from the `backend` dir. Tested this and it 1) didn't raise issues from non-existent files to ignore and 2) worked. 

I didn't find a better solution, but didn't look hard and also I don't think there's going to be a much better one on the flake8 side. But happy to close this if there's another solution that's better. 